### PR TITLE
[Do not merge or delete] Changes required for generating package for RSA-CAS 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,7 @@ runs:
         cd Python-3.7.3
         ./configure --enable-optimizations
         sudo make altinstall
+        cd ..
         python3.7 --version
         python3.7 -m pip install --upgrade pip --user
         python3.7 -m pip install virtualenv

--- a/action.yml
+++ b/action.yml
@@ -32,16 +32,16 @@ runs:
         if [ -f "Pipfile.lock" ]
         then
           mkdir -p package/lib || true
-          python3.7 -m pip install pipenv
-          python3.7 -m pipenv lock -r > package/lib/requirements.txt
-          python3.7 -m pipenv lock -d -r > requirements_dev.txt
+          pip install pipenv
+          pipenv lock -r > package/lib/requirements.txt
+          pipenv lock -d -r > requirements_dev.txt
         fi
     - shell: bash
       run: |
         if [ -f "poetry.lock" ]
         then
           mkdir -p package/lib || true
-          python3.7 -m pip install poetry
+          pip install poetry
           poetry export --without-hashes -o package/lib/requirements.txt
           poetry export --without-hashes --dev -o requirements_dev.txt
           if [ ! -z $INPUT_VERSION ]
@@ -52,15 +52,25 @@ runs:
     - run: |
         if [ ! -z $INPUT_VERSION ]; then ARG_VERSION="--ta-version=${INPUT_VERSION}"; fi
         echo "::set-output name=result::$(echo $ARG_VERSION)"
-        echo running ucc-gen $ARG_VERSION
+        echo "Installing Python 3.7.3"
+        sudo apt update
+        sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev
+        wget https://www.python.org/ftp/python/3.7.3/Python-3.7.3.tgz
+        tar -xf Python-3.7.3.tgz
+        cd Python-3.7.3
+        ./configure --enable-optimizations
+        sudo make altinstall
+        python3.7 --version
+        python3.7 -m pip install --upgrade pip --user
         python3.7 -m pip install virtualenv
         python3.7 -m virtualenv venv373
         source venv373/bin/activate
+        echo "Inside Virtualenv"
         python -V
         pip install -r requirements_dev.txt
         pip list | grep splunk-add-on-ucc-framework
+        echo running ucc-gen $ARG_VERSION
         ucc-gen $ARG_VERSION
-        ls -al output/Splunk_TA_rsa_securid_cas/lib/Crypto/Cipher
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}

--- a/action.yml
+++ b/action.yml
@@ -49,13 +49,17 @@ runs:
             poetry version $INPUT_VERSION
           fi
         fi
-    - shell: bash
-      run: python3.7 -m pip install -r requirements_dev.txt
     - run: |
         if [ ! -z $INPUT_VERSION ]; then ARG_VERSION="--ta-version=${INPUT_VERSION}"; fi
         echo "::set-output name=result::$(echo $ARG_VERSION)"
         echo running ucc-gen $ARG_VERSION
-        python3.7 -m ucc-gen $ARG_VERSION
+        python3.7 -m pip install virtualenv
+        python3.7 -m virtualenv venv373
+        source venv373/bin/activate
+        python -V
+        pip install -r requirements_dev.txt
+        pip list | grep splunk-add-on-ucc-framework
+        ucc-gen $ARG_VERSION
         ls -al output/Splunk_TA_rsa_securid_cas/lib/Crypto/Cipher
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -52,6 +52,7 @@ runs:
     - run: |
         if [ ! -z $INPUT_VERSION ]; then ARG_VERSION="--ta-version=${INPUT_VERSION}"; fi
         echo "::set-output name=result::$(echo $ARG_VERSION)"
+        ls -al
         echo "Installing Python 3.7.3"
         sudo apt update
         sudo apt install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libsqlite3-dev libreadline-dev libffi-dev wget libbz2-dev

--- a/action.yml
+++ b/action.yml
@@ -32,16 +32,16 @@ runs:
         if [ -f "Pipfile.lock" ]
         then
           mkdir -p package/lib || true
-          pip install pipenv
-          pipenv lock -r > package/lib/requirements.txt
-          pipenv lock -d -r > requirements_dev.txt
+          python3.7 -m pip install pipenv
+          python3.7 -m pipenv lock -r > package/lib/requirements.txt
+          python3.7 -m pipenv lock -d -r > requirements_dev.txt
         fi
     - shell: bash
       run: |
         if [ -f "poetry.lock" ]
         then
           mkdir -p package/lib || true
-          pip install poetry
+          python3.7 -m pip install poetry
           poetry export --without-hashes -o package/lib/requirements.txt
           poetry export --without-hashes --dev -o requirements_dev.txt
           if [ ! -z $INPUT_VERSION ]
@@ -50,12 +50,13 @@ runs:
           fi
         fi
     - shell: bash
-      run: pip install -r requirements_dev.txt
+      run: python3.7 -m pip install -r requirements_dev.txt
     - run: |
         if [ ! -z $INPUT_VERSION ]; then ARG_VERSION="--ta-version=${INPUT_VERSION}"; fi
         echo "::set-output name=result::$(echo $ARG_VERSION)"
         echo running ucc-gen $ARG_VERSION
-        ucc-gen $ARG_VERSION
+        python3.7 -m ucc-gen $ARG_VERSION
+        ls -al output/Splunk_TA_rsa_securid_cas/lib/Crypto/Cipher
       shell: bash
       env:
         INPUT_VERSION: ${{ inputs.version }}


### PR DESCRIPTION
**- In order for the main workflow for RSA-SecureId-CAS to work this branch needs to remain active.** Since this updated code is use in the workflow for generating build
- Addon's build generated via ucc-gen only works when generated with Python 3.7.3 hence updated the action accordingly
- For builds generated with other python versions (3.7.1, 3.7.6, 3.7.12, 3.8.10) UI pages are not loading (500 error) and Modinputs are not initialized.
 
![image](https://user-images.githubusercontent.com/61701682/136506220-d6a32082-74f7-4ed6-adf5-24f6058ae95e.png)
![image](https://user-images.githubusercontent.com/61701682/136506236-963af21a-7145-4ee9-a48f-538e6390cd6e.png)

- The Workflow where UI tests are executing successfully: https://github.com/splunk/splunk-add-on-for-rsa-securid-cas/actions/runs/1319239151
- A jira is filed for addon team to fix the pycrypto issue. ref: [ADDON-43320](https://jira.splunk.com/browse/ADDON-43320)