### PR TITLE
feat(poetry): bump poetry version to v1.5.1

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       run: |
         if [ -f "poetry.lock" ]
         then
-          pip install poetry==1.2.2 poetry-plugin-export==1.2.0
+          pip install poetry==1.5.1 poetry-plugin-export==1.4.0
           poetry export --without-hashes -o requirements.txt
           if [ "$(grep -cve '^\s*$' requirements.txt)" -ne 0 ]
           then


### PR DESCRIPTION
This PR bumps `poetry` version to 1.5.1 which is last version that supports Python 3.7 as well as updates `poetry-plugin-export` to v1.4.0.

We are going to release it as a v2.0.0 of this action so we don't break any existing users of this action.