### PR TITLE
fix: extend permissions for workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,14 @@ on:
     branches:
       - "main"
       - "develop"
-
+permissions:
+  actions: read
+  checks: write
+  contents: write
+  deployments: read
+  packages: write
+  pull-requests: read
+  statuses: write
 jobs:
   build_action:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Extend permissions - use same as are being used across TA repos.
Currently identified permissions issue when semver action is trying to push new tags to the repo.